### PR TITLE
Bump Truth to 1.4.2. (#270)

### DIFF
--- a/jung-api/pom.xml
+++ b/jung-api/pom.xml
@@ -26,11 +26,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.truth.extensions</groupId>
-      <artifactId>truth-java8-extension</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>test</scope>

--- a/jung-api/src/test/java/edu/uci/ics/jung/graph/AbstractCTreeTest.java
+++ b/jung-api/src/test/java/edu/uci/ics/jung/graph/AbstractCTreeTest.java
@@ -11,7 +11,7 @@
 package edu.uci.ics.jung.graph;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static edu.uci.ics.jung.graph.TestUtil.FAIL_ERROR_ELEMENT_NOT_IN_TREE;
 import static edu.uci.ics.jung.graph.TestUtil.FAIL_ERROR_NODEU_NOT_IN_TREE;
 import static edu.uci.ics.jung.graph.TestUtil.FAIL_ERROR_NODEV_IN_TREE;
@@ -471,12 +471,12 @@ public abstract class AbstractCTreeTest {
   @Test
   public void depth_multipleEdges() {
     buildTreeWithMultipleEdges();
-    assertThat(tree.depth(N1)).named("tree.depth(%s)", N1).isEqualTo(0);
-    assertThat(tree.depth(N2)).named("tree.depth(%s)", N2).isEqualTo(1);
-    assertThat(tree.depth(N3)).named("tree.depth(%s)", N3).isEqualTo(1);
-    assertThat(tree.depth(N4)).named("tree.depth(%s)", N4).isEqualTo(2);
-    assertThat(tree.depth(N5)).named("tree.depth(%s)", N5).isEqualTo(2);
-    assertThat(tree.depth(N6)).named("tree.depth(%s)", N6).isEqualTo(3);
+    assertWithMessage("tree.depth(%s)", N1).that(tree.depth(N1)).isEqualTo(0);
+    assertWithMessage("tree.depth(%s)", N2).that(tree.depth(N2)).isEqualTo(1);
+    assertWithMessage("tree.depth(%s)", N3).that(tree.depth(N3)).isEqualTo(1);
+    assertWithMessage("tree.depth(%s)", N4).that(tree.depth(N4)).isEqualTo(2);
+    assertWithMessage("tree.depth(%s)", N5).that(tree.depth(N5)).isEqualTo(2);
+    assertWithMessage("tree.depth(%s)", N6).that(tree.depth(N6)).isEqualTo(3);
   }
 
   @Test

--- a/jung-api/src/test/java/edu/uci/ics/jung/graph/CTreeMutationTest.java
+++ b/jung-api/src/test/java/edu/uci/ics/jung/graph/CTreeMutationTest.java
@@ -11,7 +11,6 @@
 package edu.uci.ics.jung.graph;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static java.lang.Boolean.TRUE;
 import static java.util.stream.Collectors.toCollection;
 

--- a/jung-samples/pom.xml
+++ b/jung-samples/pom.xml
@@ -14,7 +14,7 @@
   </description>
   <properties>
     <version.slf4j>1.7.25</version.slf4j>
-    <version.logback>1.2.9</version.logback>
+    <version.logback>1.3.15</version.logback>
   </properties>
   <dependencies>
     <dependency>

--- a/jung-visualization/pom.xml
+++ b/jung-visualization/pom.xml
@@ -11,7 +11,7 @@
   <description>Core visualization support for the JUNG project</description>
   <properties>
     <version.slf4j>1.7.25</version.slf4j>
-    <version.logback>1.2.9</version.logback>
+    <version.logback>1.3.15</version.logback>
   </properties>
   <dependencies>
      <dependency>

--- a/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/annotations/AnnotationPaintable.java
+++ b/jung-visualization/src/main/java/edu/uci/ics/jung/visualization/annotations/AnnotationPaintable.java
@@ -25,7 +25,7 @@ import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Point2D;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.swing.JComponent;
 
@@ -37,7 +37,7 @@ import javax.swing.JComponent;
 public class AnnotationPaintable implements VisualizationServer.Paintable {
 
   @SuppressWarnings("rawtypes")
-  protected Set<Annotation> annotations = new HashSet<Annotation>();
+  protected Set<Annotation> annotations = new LinkedHashSet<Annotation>();
 
   protected AnnotationRenderer annotationRenderer;
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <java.version>1.8</java.version>
 
     <junit.version>4.13.1</junit.version>
-    <truth.version>0.36</truth.version>
+    <truth.version>1.4.2</truth.version>
     <guava.version>31.1-jre</guava.version>
     <google-java-format.version>1.15.0</google-java-format.version>
 
@@ -130,11 +130,6 @@
       <dependency>
         <groupId>com.google.truth</groupId>
         <artifactId>truth</artifactId>
-        <version>${truth.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.truth.extensions</groupId>
-        <artifactId>truth-java8-extension</artifactId>
         <version>${truth.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
     <junit.version>4.13.1</junit.version>
     <truth.version>1.4.2</truth.version>
-    <guava.version>31.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <google-java-format.version>1.15.0</google-java-format.version>
 
     <cobertura.plugin.version>2.7</cobertura.plugin.version>


### PR DESCRIPTION
This eliminates the need for `Truth8`, whose functionality is now available in `Truth` itself. (This includes eliminating the need for the `truth-java8-extension` artifact.)

It also requires us to move off `named` in favor of `assertWithMessage`.